### PR TITLE
Fixed bug caused by sharedPreference being unable to store double

### DIFF
--- a/OOPP/app/src/main/java/com/example/sauronsarmy/oopp/MainModel.java
+++ b/OOPP/app/src/main/java/com/example/sauronsarmy/oopp/MainModel.java
@@ -41,11 +41,11 @@ class MainModel implements MainMVPInterface.ModelInterface {
 
         saveState = context.getSharedPreferences(context.getString(R.string.stateIdentifier), Context.MODE_PRIVATE);
         editor = saveState.edit();
-        editor.putInt("damage",       (int) currentState.get("damage"));
-        editor.putFloat("damageMult", (float) currentState.get("damageMult"));
-        editor.putInt("money",        (int) currentState.get("money"));
-        editor.putInt("moneyPerSec",  (int) currentState.get("moneyPerSec"));
-        editor.putLong("lastLogOn",   (long) currentState.get("lastLogOn"));
+        editor.putInt("damage",        (int) currentState.get("damage"));
+        editor.putLong("damageMult",   doubleToLong((double) currentState.get("damageMult")));
+        editor.putInt("money",         (int) currentState.get("money"));
+        editor.putLong("moneyPerSec",  doubleToLong((double) currentState.get("moneyPerSec")));
+        editor.putLong("lastLogOn",    (long) currentState.get("lastLogOn"));
         editor.apply();
     }
 
@@ -64,11 +64,34 @@ class MainModel implements MainMVPInterface.ModelInterface {
        return new HashMap<String, Object>() {
            {
                put("damage",      saveState.getInt("damage", 10));
-               put("damageMult",  saveState.getFloat("damageMult", 1.0f));
+               put("damageMult",  longToDouble(saveState.getLong("damageMult", doubleToLong(1.0))));
                put("money",       saveState.getInt("money", 10));
-               put("moneyPerSec", saveState.getInt("moneyPerSec", 0));
+               put("moneyPerSec", longToDouble(saveState.getLong("moneyPerSec", 0)));
                put("lastLogOn",   saveState.getLong("lastLogOn", -1));
            }
        };
    }
+
+    /**
+     * SharedPreference is (for some reason) not able to save doubles.
+     * This leaves me with two options, either casting the double to a float,
+     * which is a lossy conversion and widely regarded as a bad move. Or
+     * I could convert the value of the double to it's raw long bits equivalent
+     * and store this as a long instead. I choose the latter.
+     * @param heathen The value to convert
+     * @return The converted value
+     */
+    private long doubleToLong(double heathen) {
+        return Double.doubleToRawLongBits(heathen);
+    }
+
+    /**
+     * Reverts the converted double value to its true form.
+     * @param convert The converted value.
+     * @return The true form
+     */
+    private double longToDouble(long convert) {
+        return Double.longBitsToDouble(convert);
+    }
+
 }

--- a/OOPP/app/src/main/java/com/example/sauronsarmy/oopp/PlayerModel.java
+++ b/OOPP/app/src/main/java/com/example/sauronsarmy/oopp/PlayerModel.java
@@ -15,7 +15,7 @@ public class PlayerModel implements  PlayerModelInterface{
     private static final PlayerModel ourInstance = new PlayerModel();
 
     private int damage;
-    private float damageMultiplier;
+    private double damageMultiplier;
     private int money;
     private double moneyPerSecond;
     // This must be assigned when exiting the app.
@@ -32,9 +32,8 @@ public class PlayerModel implements  PlayerModelInterface{
      */
     private PlayerModel() {
         damage           = 10;
-        damageMultiplier = 1.0f;
+        damageMultiplier = 1.0;
         money            = 50;
-
         moneyPerSecond   = 0;
     }
 
@@ -46,11 +45,11 @@ public class PlayerModel implements  PlayerModelInterface{
         this.lastLogOn = lastLogOn;
     }
 
-    public float getDamageMultiplier() {
+    public double getDamageMultiplier() {
         return damageMultiplier;
     }
 
-    public void setDamageMultiplier(float damageMultiplier) {
+    public void setDamageMultiplier(double damageMultiplier) {
         this.damageMultiplier = damageMultiplier;
     }
 
@@ -80,11 +79,11 @@ public class PlayerModel implements  PlayerModelInterface{
 
     @Override
     public void setState(Map newState) {
-        setDamage((int) newState.get("damage"));
-        setDamageMultiplier((float) newState.get("damageMult"));
-        setMoney((int) newState.get("money"));
-        setMoneyPerSecond((int) newState.get("moneyPerSec"));
-        setLastLogOn((long) newState.get("lastLogOn"));
+        setDamage(          (int) newState.get("damage"));
+        setDamageMultiplier((double) newState.get("damageMult"));
+        setMoney(           (int) newState.get("money"));
+        setMoneyPerSecond(  (double) newState.get("moneyPerSec"));
+        setLastLogOn(       (long) newState.get("lastLogOn"));
     }
 
     @Override

--- a/OOPP/app/src/main/java/com/example/sauronsarmy/oopp/PlayerModelInterface.java
+++ b/OOPP/app/src/main/java/com/example/sauronsarmy/oopp/PlayerModelInterface.java
@@ -1,7 +1,7 @@
 package com.example.sauronsarmy.oopp;
 
 /**
- * Created by Loke on 13/04/17.
+ * Created by Erik on 13/04/17.
  */
 
 public interface PlayerModelInterface {
@@ -9,8 +9,8 @@ public interface PlayerModelInterface {
     void setLastLogOn(long newValue);
     long getLastLogOn();
 
-    void setDamageMultiplier(float newValue);
-    float getDamageMultiplier();
+    void setDamageMultiplier(double newValue);
+    double getDamageMultiplier();
 
     void setDamage(int newValue);
     int getDamage();

--- a/OOPP/app/src/main/java/com/example/sauronsarmy/oopp/Shop.java
+++ b/OOPP/app/src/main/java/com/example/sauronsarmy/oopp/Shop.java
@@ -43,7 +43,7 @@ class Shop {
     protected boolean buyMultiplierUpgrade(){
         if (player.getMoney() >= multiplierUpgrade.getCost()) {
             player.setMoney(player.getMoney() - multiplierUpgrade.getCost());
-            player.setDamageMultiplier(player.getDamageMultiplier() + (float) multiplierUpgrade.getStat());
+            player.setDamageMultiplier(player.getDamageMultiplier() + multiplierUpgrade.getStat());
 
             multiplierUpgradeCounter++;
             multiplierUpgrade.updateStat(multiplierUpgradeCounter);


### PR DESCRIPTION
SharedPreference is (for some reason) not able to save doubles.
This leaves me with two options, either casting the double to a float,
which is a lossy conversion and widely regarded as a bad move. Or
I could convert the value of the double to it's raw long bits equivalent
 and store this as a long instead. I choose the latter.